### PR TITLE
fix: remove prefix in version name

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,6 @@
 # Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: 'v$RESOLVED_VERSION 🌈'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
 
 version-resolver:
   major:


### PR DESCRIPTION
Should fix https://github.com/jenkins-infra/packer-images/issues/227

Shouldn't impact other repositories as they surchage on their own these parameters: https://cs.github.com/?scope=org%3Ajenkins-infra&scopeName=jenkins-infra&q=_extends%3A+.github