### PR TITLE
Disable all `github-comment-op` commands except `/reviewer`

### DIFF
--- a/.github/comment-ops.yml
+++ b/.github/comment-ops.yml
@@ -1,0 +1,11 @@
+commands:
+  label:
+    enabled: false
+  removeLabel:
+    enabled: false
+  reopen:
+    enabled: false
+  reviewer:
+    enabled: true
+  transfer:
+    enabled: false


### PR DESCRIPTION
see 
- https://github.com/jenkins-infra/helpdesk/issues/3074
- https://github.com/timja/github-comment-ops/releases/tag/v1.3.0