### PR TITLE
chore: resize Hacktoberfest logo on jenkins-infra profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -24,8 +24,8 @@ https://github.com/jenkinsci/
 
 <a href="https://www.jenkins.io/events/hacktoberfest/">
   <picture>
-      <source width="400" media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/13383509/192602080-715854aa-eaeb-442c-b208-9b5595a7c376.svg">
-      <img width="400" src="https://user-images.githubusercontent.com/13383509/192601744-52ccbb5e-3d51-4f07-b76d-2fc927bfacfb.svg">
+      <source width="200" media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/13383509/192602080-715854aa-eaeb-442c-b208-9b5595a7c376.svg">
+      <img width="200" src="https://user-images.githubusercontent.com/13383509/192601744-52ccbb5e-3d51-4f07-b76d-2fc927bfacfb.svg">
   </picture>
 </a>
 <br/>


### PR DESCRIPTION
More equilibrated size compared to the rest of the profile.

<details>
<summary>Before</summary>

<img width="935" alt="image" src="https://user-images.githubusercontent.com/91831478/193684046-79656559-4f6a-404d-bc68-f465f72c84b4.png">

</details>

<details>
<summary>After</summary>

<img width="948" alt="image" src="https://user-images.githubusercontent.com/91831478/193683979-e30aceb5-8b3a-4182-a6f3-34c04365b37a.png">


</details>