### PR TITLE
chore: add a link to search hacktoberfest repos in jenkinsci & jenkins-infra

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -32,4 +32,4 @@ https://github.com/jenkinsci/
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories) 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories "repositories participating in Hacktoberfest") 🎉

--- a/profile/README.md
+++ b/profile/README.md
@@ -32,4 +32,4 @@ https://github.com/jenkinsci/
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories "repositories participating in Hacktoberfest") 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?o=desc&q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&s=updated&type=Repositories "repositories participating in Hacktoberfest") 🎉

--- a/profile/README.md
+++ b/profile/README.md
@@ -32,4 +32,4 @@ https://github.com/jenkinsci/
 <br/>
 
 The Jenkins community is participating in Hacktoberfest again, and we are looking for contributors and maintainers who want to join us in October!  
-[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions towards the Jenkins project 🎉
+[Learn more about this year's Hacktoberfest](https://www.jenkins.io/events/hacktoberfest/), and how to make your contributions [towards the Jenkins project](https://github.com/search?q=topic%3Ahacktoberfest+org%3Ajenkins-infra+org%3Ajenkinsci+fork%3Atrue&type=repositories) 🎉


### PR DESCRIPTION
Add a link to a search of the repositories of jenkinsci and jenkins-infra tagged with "hacktoberfest"

~~PTAL at this suggestion too: https://github.com/jenkinsci/.github/pull/98#discussion_r995097239~~
Using "recently updated" sort, more chance for the PRs to be quickly reviewed and merged.

Related: https://github.com/jenkinsci/.github/pull/98
