### PR TITLE
Adapt config to comment-ops 1.4.0

### DIFF
--- a/.github/comment-ops.yml
+++ b/.github/comment-ops.yml
@@ -1,11 +1,3 @@
 commands:
-  label:
-    enabled: false
-  removeLabel:
-    enabled: false
-  reopen:
-    enabled: false
   reviewer:
     enabled: true
-  transfer:
-    enabled: false


### PR DESCRIPTION
Commands are now disabled by default, so you only need to enable, see
https://github.com/jenkins-infra/.github/pull/15#pullrequestreview-1056980315