### PR TITLE
Update Gitter URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,4 +17,4 @@ See the Contributing guidelines [on jenkins.io](https://jenkins.io/projects/infr
 
 ## Newcomers
 
-If you are a newcomer contributor and have any questions, please do not hesitate to ask in the `#jenkins-infra` IRC channel as explained [here](https://jenkins.io/chat/#jenkins-infra) or in the [Newcomers Gitter channel](https://gitter.im/jenkinsci/newcomer-contributors).
+If you are a newcomer contributor and have any questions, please do not hesitate to ask in the `#jenkins-infra` IRC channel as explained [here](https://jenkins.io/chat/#jenkins-infra) or in the [Newcomers Gitter channel](https://app.gitter.im/#/room/#jenkinsci_newcomer-contributors:gitter.im).


### PR DESCRIPTION
Since yesterday, February the 13th, Gitter migrated to matrix. Existing links are redirected, but some redirections broke or use a different URL.
This PR updates the link to use the final destination, to ensure we don't rely on possible breaking redirections.