### PR TITLE
Update the Jenkins Award timeline

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -33,8 +33,8 @@ Nominated candidates are:
 [Voting is open](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform)
 
 Awards timeline:
-- Nominations close: Friday, March 3
-- Voting opens: Wednesday, March 8
+- Nominations deadline: Friday, March 3 (nominations closed)
+- Voting opens: Wednesday, March 8 ([voting form](https://docs.google.com/forms/d/e/1FAIpQLScUL4GAL-6wOjHKbT86ptKSStnglKM9_MKTQXzjgwimCDEtGw/viewform))
 - Voting closes: Tuesday, March 28
 - Winners announced at cdCon + GitOpsCon: May 8 – 9, 2023
 


### PR DESCRIPTION
This pr proposes to update the Jenkins Awards timeline:
- nominations are now closed
- add the voting form link