### PR TITLE
Update release-drafter replacers

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -84,12 +84,8 @@ template: |
 replacers:
   - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
     replace: '[JENKINS-$1](https://issues.jenkins-ci.org/browse/JENKINS-$1) - '
-  - search: '/\[*INFRA-(\d+)\]*\s*-*\s*/g'
-    replace: '[INFRA-$1](https://issues.jenkins-ci.org/browse/INFRA-$1) - '
-  - search: '/\[*WEBSITE-(\d+)\]*\s*-*\s*/g'
-    replace: '[WEBSITE-$1](https://issues.jenkins-ci.org/browse/WEBSITE-$1) - '
-  - search: '/\[*HOSTING-(\d+)\]*\s*-*\s*/g'
-    replace: '[HOSTING-$1](https://issues.jenkins-ci.org/browse/HOSTING-$1) - '
+  - search: '/\[*HELPDESK-(\d+)\]*\s*-*\s*/g'
+    replace: '[HELPDESK-$1](https://github.com/jenkins-infra/helpdesk/issues/$1) - '
   # TODO(oleg_nenashev): Find a better way to reference issues
   - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
     replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '


### PR DESCRIPTION
As INFRA, HOSTING or WEBSITE Jira issues [cannot be created anymore](https://github.com/jenkins-infra/helpdesk/issues/3268), this PR removes the corresponding replacers, and add a new one for the Jenkins Infra help desk issues.

Twin PR: https://github.com/jenkinsci/.github/pull/121 