### PR TITLE
feat: add @jenkins-infra issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yml
@@ -1,0 +1,43 @@
+name: '🐛 Bug report'
+labels: ['bug']
+description: Create a bug report to help us improve
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Never report security issues on GitHub or other public channels (Gitter/Twitter/etc.)**
+        Follow these instruction to report security issues: https://www.jenkins.io/security/#reporting-vulnerabilities
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: |
+        Write bullet-point reproduction steps.
+        Be explicit about any relevant configuration, jobs, build history, user accounts, etc., redacting confidential information as needed.
+        The best reproduction steps start with a clean Jenkins install, perhaps a `docker run` command if possible.
+        Use screenshots where appropriate, copy textual output otherwise. When in doubt, do both.
+        Include relevant logs, debug if needed - https://www.jenkins.io/doc/book/system-administration/viewing-logs/
+      placeholder: |
+        1. Step 1: ...
+        2. Step 2: ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Results
+      description: What was your expected result?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Results
+      description: What was the actual result?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: You can provide additional context below.

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,16 @@
+name: '🚀 Feature request'
+labels: ['enhancement']
+description: I have a suggestion
+
+body:
+  - type: textarea
+    attributes:
+      label: What feature do you want to see added?
+      description: A clear and concise description of your feature request.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Upstream changes
+      description: Link here any upstream changes that might be relevant to this request

--- a/.github/ISSUE_TEMPLATE/3-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yml
@@ -1,0 +1,15 @@
+name: '📝 Documentation'
+labels: ['documentation']
+description: 'Let us know if any documentation is missing or could be improved'
+
+body:
+  - type: textarea
+    attributes:
+      label: Describe your use-case which is not covered by existing documentation.
+      description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Community forum
+    url: https://community.jenkins.io/tag/sig-infra
+    about: Please ask and answer questions here
+  - name: Mailing lists
+    url: https://www.jenkins.io/mailing-lists/#jenkins-infra-googlegroups-com
+    about: You can also raise a question in Jenkins Infrastructure mailing list


### PR DESCRIPTION
This PR adds issue templates for @jenkins-infra GitHub organization, similar to the ones defined for @jenkinsci organization: https://github.com/jenkinsci/.github/issues/new/choose

Differences:
- No Jenkins Core, plugins and OS version asked in 1-bug-report
- Links to community and mailing lists tailored for Jenkins Infra

Closes https://github.com/jenkins-infra/helpdesk/issues/3