### PR TITLE
Contributors Awards 2024: add list of nominees and link to vote

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,12 +21,26 @@ https://github.com/jenkinsci/
 
 ### Jenkins Contributor Awards 2024
 
-The annual Jenkins awards is happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins.
+The annual Jenkins awards is happening now! It recognizes contributions from individuals in the community and the progress made in the name of Jenkins.  
 
-Nomination categories are:
-- Most Valuable Jenkins Advocate → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/7030)
-- Most Valuable Jenkins Contributor → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/7028)
-- Jenkins Security MVP → [Nominate Someone](https://github.com/jenkins-infra/jenkins.io/issues/7029)
+Nominated candidates are:
+- [Most Valuable Jenkins Advocate](https://github.com/jenkins-infra/jenkins.io/issues/7030):
+  - [Alexander Brandes](https://github.com/NotMyFault)
+  - [Bruno Verachten](https://github.com/gounthar)
+  - [Darin Pope](https://github.com/darinpope)
+  - [Kris Stern](https://github.com/krisstern)
+- [Most Valuable Jenkins Contributor](https://github.com/jenkins-infra/jenkins.io/issues/7028):
+  - [Basil Crow](https://github.com/basil)
+  - [Daniel Beck](https://github.com/daniel-beck)
+  - [Kris Stern](https://github.com/krisstern)
+  - [Stefan Spieker](https://github.com/StefanSpieker)
+  - [Tim Jacomb](https://github.com/timja)
+  - [Ullrich Hafner](https://github.com/uhafner)
+- [Jenkins Security MVP](https://github.com/jenkins-infra/jenkins.io/issues/7029):
+  - [Alvaro Muñoz](https://github.com/pwntester)
+  - [Yaniv Nizry](https://github.com/Yaniv-git)
+
+**📨 Vote now by filling out [this Google form](https://docs.google.com/forms/d/e/1FAIpQLScUHeNX-4H5jboVo6nRxo0-JtMiA8pLvMq2VkNYceax4frHPQ/viewform)!**
 
 Awards timeline:
 - Nominations close: February 19, 2024
@@ -34,4 +48,4 @@ Awards timeline:
 - Voting closes: March 22
 - Winners announced at cdCon 2024 on April 16 - 18, 2024
 
-See the [announcement blogpost](https://www.jenkins.io/blog/2024/01/29/nominate-someone-2024-jenkins-contributor-awards/) for more details for voting and nominate candidates.
+See the [announcement blogpost](https://www.jenkins.io/blog/2024/01/29/nominate-someone-2024-jenkins-contributor-awards/) for more details.


### PR DESCRIPTION
This PR adds the list of nominees and the link to the Google form to vote.

Follow-up of:
- #45 

Related:
- https://github.com/jenkinsci/.github/pull/134